### PR TITLE
Enforce UNIX line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Following the guidance [here](https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html#_end_of_line_conversion), enforce all `*.sh` files to have plain UNIX newlines. This should address some Windows provisioning errors.

This addresses issue #18.
