### PR TITLE
Drush aliases and remote hosts

### DIFF
--- a/examples/drupal/site.aliases.drushrc.php
+++ b/examples/drupal/site.aliases.drushrc.php
@@ -58,3 +58,18 @@ $aliases['prod'] = array(
     ),
   ),
 );
+
+// Unset remote-host if drush command is being performed on the remote host,
+// which will allow the command to work when the user doesn't have shell 
+// access to itself.
+// Credit: http://www.mediacurrent.com/blog/make-your-drush-aliases-work-local-and-remote
+$ip = gethostbyname(php_uname('n'));
+foreach ($aliases as &$alias) {
+  if (empty($alias['remote-host'])) {
+    continue;
+  }
+  if (gethostbyname($alias['remote-host']) === $ip) {
+    unset($alias['remote-host']);
+  }
+}
+


### PR DESCRIPTION
Updates drush alias template to unset remote-host when on the remote host. This allows alias commands to work on the remote host when the user doesn't have ssh access to itself. closes #53.

Credit belongs to http://www.mediacurrent.com/blog/make-your-drush-aliases-work-local-and-remote.
