### PR TITLE
Move drush initialization tasks to follow release completion.

### DIFF
--- a/capistrano/drupal.rb
+++ b/capistrano/drupal.rb
@@ -6,8 +6,8 @@ end
 # Backup the database when publishing a new release
 Rake::Task["deploy:publishing"].enhance ["drupal:dbbackup"]
 
-# Copy drush aliases when we check compatibility
-Rake::Task["deploy:check"].enhance ["drush:initialize"]
+# Copy drush aliases after linking the new release
+Rake::Task["deploy:symlink:release"].enhance ["drush:initialize"]
 
 # After publication run updates
 Rake::Task["deploy:published"].enhance do 


### PR DESCRIPTION
Previously the initilization process ran after checking for deployment
folders regardless of the status of this check. Moving this later in the
process fixes #39 by postponing the file copy process until after the
new release is linked.

Fixes #39 
