### PR TITLE
Load gem dependencies dynamically from the theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,10 @@ source 'https://rubygems.org'
 
 gem 'capistrano', '~>3.1'
 gem 'rake'
-gem 'compass'
-gem 'breakpoint'
-gem 'singularitygs'
-gem 'singularity-extras'
+
+# Load gem dependencies from the theme
+theme_gemfile = File.join(File.dirname(__FILE__), "public/sites/all/themes/f1ux/Gemfile")
+if File.exists?(theme_gemfile)
+  puts "Loading #{theme_gemfile} ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(theme_gemfile)
+end

--- a/_Gemfile
+++ b/_Gemfile
@@ -1,0 +1,19 @@
+source 'https://rubygems.org'
+
+gem 'capistrano', '~>3.1'
+gem 'rake'
+
+{{#use_compass}}
+# Load gem dependencies from the theme
+{{#is_drupal}}
+theme_gemfile = File.join(File.dirname(__FILE__), "{{app_webroot}}/sites/all/themes/{{drupal_theme}}/Gemfile")
+{{/is_drupal}}
+{{#is_wordpress}}
+theme_gemfile = File.join(File.dirname(__FILE__), "{{app_webroot}}/wp-content/themes/{{wordpress_theme}}/Gemfile")
+{{/is_wordpress}}
+if File.exists?(theme_gemfile)
+  puts "Loading #{theme_gemfile} ..." if $DEBUG # `ruby -d` or `bundle -v`
+  instance_eval File.read(theme_gemfile)
+end
+{{^is_drupal}}
+{{/use_compass}}

--- a/_Gemfile
+++ b/_Gemfile
@@ -15,5 +15,4 @@ if File.exists?(theme_gemfile)
   puts "Loading #{theme_gemfile} ..." if $DEBUG # `ruby -d` or `bundle -v`
   instance_eval File.read(theme_gemfile)
 end
-{{^is_drupal}}
 {{/use_compass}}


### PR DESCRIPTION
This fixes #65 by replacing explictly defined dependencies in the overall Gemfile with an attempt to dynamically load them from the theme's Gemfile.

The implementation suggested here defines a default path to the theme assuming a Drupal platform. If it can't find the file it shouldn't fail, but individual projects will likely need to update this path manually. A more permanent solution is also in the works by adding a new template file for `Gemfile` to dynamically generate it via the web-starter generator, but until forumone/generator-web-starter#7 is resolved this template file isn't used.
