### PR TITLE
Create a self-signed cert before provision

### DIFF
--- a/puppet/shell/pre-provision.sh
+++ b/puppet/shell/pre-provision.sh
@@ -2,6 +2,11 @@
 
 VAGRANT_CORE_FOLDER="/vagrant"
 
+# Create default self-signed SSL cert.
+if [[ ! -f "/etc/pki/tls/private/localhost.key" ]]; then
+    /usr/bin/openssl req -newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key  -x509 -days 365 -out /etc/pki/tls/certs/localhost.crt -subj '/CN=localhost.localdomain' > /dev/null
+fi
+
 if [[ -f "${VAGRANT_CORE_FOLDER}/puppet/shell/custom/pre-provision.sh" ]]; then
   source ${VAGRANT_CORE_FOLDER}/puppet/shell/custom/pre-provision.sh
 fi;


### PR DESCRIPTION
Related to #52 

NGINX (and puppet in general) lacks the ability to generate certs for itself, so we do it in pre-provision.sh . 

This step is redundant when hosting on Apache, using the box without a web server, or using puppet-forumone < 1.1.25 (or without the patch from https://github.com/forumone/puppet-forumone/issues/6 ), but it's a minimal performance cost in vagrant up, so it should be OK.
