### PR TITLE
Drush alias location

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ If the virtual machine does not boot up and you get a message saying there was a
 
 ## Drush Alias File
 
-A sample Drush aliase file has been included at /examples/drupal/site.aliases.drushrc.php . Simply copy this file into public/sites/all/drush and modify the hostnames inside it. You will be able to access the vagrant environment with 'drush @site.local', dev with 'drush @site.dev', etc. 
+A sample Drush alias file has been included at /examples/drupal/site.aliases.drushrc.php . Simply copy this file into public/sites/all/drush and modify the hostnames inside it. You will be able to access the vagrant environment with 'drush @site.local', dev with 'drush @site.dev', etc. 

--- a/README.md
+++ b/README.md
@@ -52,29 +52,4 @@ If the virtual machine does not boot up and you get a message saying there was a
 
 ## Drush Alias File
 
-An example alias file to connect with a Drupal site running in Virtualbox:
-
-```
-$aliases['local'] = array(
-  'parent' => '@parent',
-  'uri' => 'http://10.11.12.14',
-  'root' => '/vagrant/public',
-  'remote-host' => '10.11.12.14',
-  'remote-user' => 'vagrant',
-  'ssh-options' => "-i ~/.vagrant.d/insecure_private_key -l vagrant",
-  'db-url' => 'mysql://web:web@10.11.12.14:3306/web',
-  'databases' => array (
-    'default' => array (
-      'default' => array (
-        'database' => 'web',
-        'username' => 'web',
-        'password' => 'web',
-        'host' => '10.11.12.14',
-        'port' => '',
-        'driver' => 'mysql',
-        'prefix' => '',
-      ),
-    ),
-  ),
-);
-```
+A sample Drush aliase file has been included at /examples/drupal/site.aliases.drushrc.php . Simply copy this file into public/sites/all/drush and modify the hostnames inside it. You will be able to access the vagrant environment with 'drush @site.local', dev with 'drush @site.dev', etc. 


### PR DESCRIPTION
Update README.md to change the drush alias instructions. Instructs people to copy site.aliases.drushrc.php to public/sites/all/drush . With these changes, a site alias is automatically available from inside the site's public subdir, and you don't have to use vagrant ssh for normal operations anymore. It also solves the current problem of polluting the host system's drush aliases list.

from inside the public subdir, all of these commands work fine without vagrant ssh.

``` bash
drush @site.local status #gets status of the local install
drush @site.local si minimal #installs the "minimal" drupal profile
drush use @site.local #sets the default alias so you don't have to keep typing @site.local every time.
drush @site.local ssh #ssh into the vagrant box and CD to the site root. (better than vagrant ssh!)
```

What DOESN'T work from the host environment is drush sql-sync, since both environments are not allowed to be remote. I think this is resolved in Drush 7, but I'm not sure.
