### PR TITLE
update path to patternlab to use hyphen separation

### DIFF
--- a/tasks/config/copy.js
+++ b/tasks/config/copy.js
@@ -3,9 +3,9 @@ module.exports = function(grunt) {
     copy : {
       patternlabStyleguide : {
         expand : true,
-        cwd : '<%= pkg.themePath %>/patternlab/core/styleguide/',
+        cwd : '<%= pkg.themePath %>/pattern-lab/core/styleguide/',
         src : '**',
-        dest : '<%= pkg.themePath %>/patternlab/public/styleguide/'
+        dest : '<%= pkg.themePath %>/pattern-lab/public/styleguide/'
       }
     }
   });

--- a/tasks/config/shell.js
+++ b/tasks/config/shell.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
         command : 'php core/builder.php -g',
         options : {
           execOptions : {
-            cwd : '<%= pkg.themePath %>/patternlab'
+            cwd : '<%= pkg.themePath %>/pattern-lab'
           }
         }
       }

--- a/tasks/config/watch.js
+++ b/tasks/config/watch.js
@@ -9,7 +9,7 @@ module.exports = function(grunt) {
         tasks : [ 'compass:' + environment ],
       },
       patternlab : {
-        files : [ '<%= pkg.themePath %>/patternlab/source/**/*' ],
+        files : [ '<%= pkg.themePath %>/pattern-lab/source/**/*' ],
         tasks : [ 'shell:patternlab' ],
         options : {
           livereload : true


### PR DESCRIPTION
In current versions, we use hyphen separation for the folder path to pattern lab inside the theme: pattern-lab , not patternlab. Right, @dcmouyard ? 

Update the paths in tasks/config.

Or maybe this should be another variable in package.json?
