### PR TITLE
remove "do" from Gemfile so it works in Jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
-source 'https://rubygems.org' do
-  gem 'capistrano', '~>3.1'
-  gem 'rake'
-end
+source 'https://rubygems.org'
+gem 'capistrano', '~>3.1'
+gem 'rake'
 
 # Load gem dependencies from the theme
 theme_gemfile = File.join(File.dirname(__FILE__), "public/sites/all/themes/gesso/Gemfile")


### PR DESCRIPTION
When trying to deploy with Jenkins, the build failed, complaining that capistrano was not included in the Gemfile.

I had no trouble with "bundle install" locally, this only occurred when Jenkins tried to run it. 

The problem disappears if you remove the "do" loop in the Gemfile, as I did here. 
