### PR TITLE
Fix NFS/mount problems on unix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
 
   # Add NFS
   if (RUBY_PLATFORM =~ /linux/ or RUBY_PLATFORM =~ /darwin/)
-    config.vm.synced_folder ".", "/vagrant", :nfs => { :mount_options => ["dmode=777","fmode=666","no_root_squash"] }
+    config.vm.synced_folder ".", "/vagrant", nfs_udp: false, :nfs => { :mount_options => ["dmode=777","fmode=666","no_root_squash"] }
     config.nfs.map_uid = Process.uid
     config.nfs.map_gid = Process.gid
   else


### PR DESCRIPTION
This PR attempts to fix a recent NFS/mount problem on unix.

After recent software updates on my local Ubuntu box, NFS mounts stopped working during Vagrant up. Per the [troubleshooting docs](http://forumone.github.io/web-starter/localdev/troubleshooting.html) I'd already installed nfs-kernel-server a while back. Enabling Vagrant debugging showed timeouts after mount commands like this:

```
INFO ssh: Execute: mount -o 'vers=3,udp' 10.11.12.2:'/home/ahieb/develop/f1/git/web-starter-fork' /vagrant (sudo=true)
```

Resources like the following pointed toward disabling udp:
- https://github.com/mitchellh/vagrant/issues/2989
- https://github.com/mitchellh/vagrant/issues/1744

Indeed this works for my box, though I'm not sure how generally advisable this is or helpful it will be to others.

I'm also not sure what the specific change was for me recently that caused the breakage, but here are some relevant version numbers:

```
ahieb@ahieb-pc:~$ uname -r
3.13.0-66-generic
ahieb@ahieb-pc:~$ apt show nfs-kernel-server
[snip]
Version: 1:1.2.8-6ubuntu1.1
[snip]
ahieb@ahieb-pc:~$ vagrant --version
Vagrant 1.6.2
ahieb@ahieb-pc:~$ vboxmanage --version
4.3.10_Ubuntur93012
ahieb@ahieb-pc:~$
```
