### PR TITLE
Separate privileged and unprivileged post-provision tasks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -119,6 +119,7 @@ Vagrant.configure("2") do |config|
 
   # Run any custom scripts after provisioning
   config.vm.provision :shell, :path => "puppet/shell/post-provision.sh"
+  config.vm.provision :shell, :path => "puppet/shell/post-provision.unprivileged.sh", privileged: false
 
 end
 

--- a/puppet/shell/custom/example-drupal-post-provision.unprivileged.sh
+++ b/puppet/shell/custom/example-drupal-post-provision.unprivileged.sh
@@ -1,28 +1,33 @@
 #!/bin/bash
 
+# Post provision actions that do not require root access.
+# This version of the file contains common post-provision steps for Drupal sites.
+
+# Just rename this file to "post-provision.unprivileged.sh" to make it active.
+
 VAGRANT_CORE_FOLDER="/vagrant"
 
 if [[ -f "${VAGRANT_CORE_FOLDER}/public/sites/default/settings.vm.php" ]]; then
   if [[ ! -f "${VAGRANT_CORE_FOLDER}/public/sites/default/settings.php" || -w "${VAGRANT_CORE_FOLDER}/public/sites/default/settings.php" ]]; then
     echo 'Copying settings file'
-    su - vagrant -c "cd ${VAGRANT_CORE_FOLDER}/public/sites/default && cp settings.vm.php settings.php" >/dev/null
+    cd ${VAGRANT_CORE_FOLDER}/public/sites/default && cp settings.vm.php settings.php
   fi
 fi
 
 if [[ -f "${VAGRANT_CORE_FOLDER}/public/htaccess.dev" ]]; then
   echo 'Copying .htaccess'
-  su - vagrant -c "cd ${VAGRANT_CORE_FOLDER}/public && cp htaccess.dev .htaccess" > /dev/null
+  cd ${VAGRANT_CORE_FOLDER}/public && cp htaccess.dev .htaccess
 fi
 
 if [[ ! -d "/home/vagrant/.drush" ]]; then
   echo 'Creating drush directory'
-  su - vagrant -c "mkdir ~/.drush"
+  mkdir ~/.drush
 fi
 
 echo 'Copying aliases'
-find "${VAGRANT_CORE_FOLDER}" -maxdepth 1 -name "*.aliases.drushrc.php" -exec su - vagrant -c "cp {} ~/.drush/" \;
+find "${VAGRANT_CORE_FOLDER}" -maxdepth 1 -name "*.aliases.drushrc.php" -exec cp {} ~/.drush/ \;
 
 if [[ ! -f "/home/vagrant/.drush/drush.ini" ]]; then
   echo 'Creating drush settings'
-  su - vagrant -c "echo 'memory_limit = 512M' > ~/.drush/drush.ini"
+  echo 'memory_limit = 512M' > ~/.drush/drush.ini
 fi

--- a/puppet/shell/custom/example-post-provision.sh
+++ b/puppet/shell/custom/example-post-provision.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# A good place to put any post-provision actions that require root access.
+# Just rename this file to "post-provision.sh" to make it active.
+
+VAGRANT_CORE_FOLDER="/vagrant"
+

--- a/puppet/shell/custom/example-wordpress-post-provision.unprivileged.sh
+++ b/puppet/shell/custom/example-wordpress-post-provision.unprivileged.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 
+# Post provision actions that do not require root access.
+# This version of the file contains common post-provision steps for Wordpress sites.
+
+# Just rename this file to "post-provision.unprivileged.sh" to make it active.
+
 VAGRANT_CORE_FOLDER="/vagrant"
 
 if [[ -f "${VAGRANT_CORE_FOLDER}/public/wp-config.vm.php" ]]; then
   if [[ ! -f "${VAGRANT_CORE_FOLDER}/public/wp-config.php" || -w "${VAGRANT_CORE_FOLDER}/public/wp-config.php" ]]; then
     echo 'Copying wp-config file'
-    su - vagrant -c "cd ${VAGRANT_CORE_FOLDER}/public && cp wp-config.vm.php wp-config.php" >/dev/null
+    cd ${VAGRANT_CORE_FOLDER}/public && cp wp-config.vm.php wp-config.php
   fi
 fi
 
 if [[ -f "${VAGRANT_CORE_FOLDER}/public/htaccess.dev" ]]; then
   echo 'Copying .htaccess'
-  su - vagrant -c "cd ${VAGRANT_CORE_FOLDER}/public && cp htaccess.dev .htaccess" > /dev/null
+  cd ${VAGRANT_CORE_FOLDER}/public && cp htaccess.dev .htaccess
 fi

--- a/puppet/shell/post-provision.sh
+++ b/puppet/shell/post-provision.sh
@@ -1,23 +1,10 @@
 #!/bin/bash
 
+# Run post-provision tasks that need to be root.
+
 VAGRANT_CORE_FOLDER="/vagrant"
 
-if [[ -f "${VAGRANT_CORE_FOLDER}/Gemfile" ]]; then
-  echo 'Installing bundler gems'
-  su - vagrant -c "cd ${VAGRANT_CORE_FOLDER} && rbenv exec bundle install" >/dev/null
-fi
-
-if [[ -f "${VAGRANT_CORE_FOLDER}/package.json" ]]; then
-  echo 'Installing NPM packages'
-  su - vagrant -c "cd ${VAGRANT_CORE_FOLDER} && npm install --silent --no-bin-links" >/dev/null
-fi
-
-if [[ -f "${VAGRANT_CORE_FOLDER}/bower.json" ]]; then
-  echo 'Installing bower packages'
-  su - vagrant -c "cd ${VAGRANT_CORE_FOLDER} && bower install" >/dev/null
-fi
-
 if [[ -f "${VAGRANT_CORE_FOLDER}/puppet/shell/custom/post-provision.sh" ]]; then
-  source ${VAGRANT_CORE_FOLDER}/puppet/shell/custom/post-provision.sh
+    source ${VAGRANT_CORE_FOLDER}/puppet/shell/custom/post-provision.sh
 fi;
 

--- a/puppet/shell/post-provision.unprivileged.sh
+++ b/puppet/shell/post-provision.unprivileged.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Runs post-provision tasks as the Vagrant user
+
+VAGRANT_CORE_FOLDER="/vagrant"
+
+if [[ -f "${VAGRANT_CORE_FOLDER}/Gemfile" ]]; then
+  echo 'Installing bundler gems'
+  cd ${VAGRANT_CORE_FOLDER} && rbenv exec bundle install
+fi
+
+if [[ -f "${VAGRANT_CORE_FOLDER}/package.json" ]]; then
+  echo 'Installing NPM packages'
+  cd ${VAGRANT_CORE_FOLDER} && npm install --silent --no-bin-links
+fi
+
+if [[ -f "${VAGRANT_CORE_FOLDER}/bower.json" ]]; then
+  echo 'Installing bower packages'
+  cd ${VAGRANT_CORE_FOLDER} && bower install
+fi
+
+if [[ -f "${VAGRANT_CORE_FOLDER}/puppet/shell/custom/post-provision.unprivileged.sh" ]]; then
+  source ${VAGRANT_CORE_FOLDER}/puppet/shell/custom/post-provision.unprivileged.sh
+fi;
+


### PR DESCRIPTION
Pulling this change out independently from #81:

> Incidentally along the way, it also separates out puppet/shell/custom/post-provision.sh into two scripts: one which is run as root, and one which is run as vagrant user. This is better than having all our tasks run through sudo -c anyways.
