### PR TITLE
Detect location of insecure_private_key in drush aliases file

### DIFF
--- a/examples/drupal/site.aliases.drushrc.php
+++ b/examples/drupal/site.aliases.drushrc.php
@@ -1,12 +1,22 @@
 <?php
 
+// Figure out where the vagrant private key is stored (it moved in a recent Vagrant version)
+$local_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+$new_keyfile_path =  $local_root . '/../.vagrant/machines/default/virtualbox/private_key';
+if (is_file($new_keyfile_path)) {
+  $insecure_private_key = $new_keyfile_path;
+}
+else {
+  $insecure_private_key = '~/.vagrant.d/insecure_private_key';
+}
+
 $aliases['local'] = array(
   'parent' => '@parent',
   'uri' => 'http://10.11.12.14',
   'root' => '/vagrant/public',
   'remote-host' => '10.11.12.14',
   'remote-user' => 'vagrant',
-  'ssh-options' => "-i ~/.vagrant.d/insecure_private_key -l vagrant",
+  'ssh-options' => "-i " . $insecure_private_key . " -l vagrant",
   'db-url' => 'mysql://web:web@10.11.12.14:3306/web',
   'databases' => array (
     'default' => array (

--- a/puppet/shell/custom/example-drupal-post-provision.sh
+++ b/puppet/shell/custom/example-drupal-post-provision.sh
@@ -20,7 +20,7 @@ if [[ ! -d "/home/vagrant/.drush" ]]; then
 fi
 
 echo 'Copying aliases'
-find "${VAGRANT_CORE_FOLDER}" -maxdepth 1 -name "*.aliases.drushrc.php" -exec su - vagrant -c "cp {} ~/.drush/" \;
+su - vagrant -c "cp ${VAGRANT_CORE_FOLDER}/examples/drupal/site.aliases.drushrc.php ${VAGRANT_CORE_FOLDER}/public/sites/all/drush/aliases.drushrc.php" \;
 
 if [[ ! -f "/home/vagrant/.drush/drush.ini" ]]; then
   echo 'Creating drush settings'


### PR DESCRIPTION
The location for Vagrant's for insecure private key recently changed, from `~/.vagrant` to `<project-root>/.vagrant/machines/default/virtualbox/private_key`. This patch updates the example drush aliases file for compatiblity.

It also copies the alias file to public/sites/all/drush/aliases.drushrc.php during the example Drupal post-provision script. I'm not convinced that this is the right place or way to do this, though. We leave it up to the TA to copy settings.vm.php out of /examples/drupal, so I guess this should be a similar case?
