### PR TITLE
Update drupal.yaml

### DIFF
--- a/puppet/manifests/hieradata/platforms/drupal.yaml
+++ b/puppet/manifests/hieradata/platforms/drupal.yaml
@@ -23,6 +23,7 @@ php::ini:
   post_max_size: "100M"
   sendmail_path: "/usr/bin/env catchmail"
   max_execution_time: 180
+  max_input_vars: 3000
 
 forumone::php::settings:
   realpath_cache_size: "128K"


### PR DESCRIPTION
Per README for features, 3000 for max input is recommended if we are exporting a lot to features. We do on a regular basis. So let's bump to that recommendation:

> If you plan on creating or working with very large features (greater than 1000
> items), you may need to increase PHP's max_input_vars configuration directive.
> For example, adding the following line to your .htaccess file will increase the
> max_input_vars directive to 3000:
