### PR TITLE
Improve local drush alias

### DIFF
--- a/examples/drupal/site.aliases.drushrc.php
+++ b/examples/drupal/site.aliases.drushrc.php
@@ -1,12 +1,22 @@
 <?php
 
+// Figure out where the vagrant private key is stored (it moved in a recent Vagrant version)
+$local_root = drush_get_context('DRUSH_SELECTED_DRUPAL_ROOT');
+$new_keyfile_path =  $local_root . '/../.vagrant/machines/default/virtualbox/private_key';
+if (is_file($new_keyfile_path)) {
+  $insecure_private_key = $new_keyfile_path;
+}
+else {
+  $insecure_private_key = '~/.vagrant.d/insecure_private_key';
+}
+
 $aliases['local'] = array(
   'parent' => '@parent',
   'uri' => 'http://10.11.12.14',
   'root' => '/vagrant/public',
   'remote-host' => '10.11.12.14',
   'remote-user' => 'vagrant',
-  'ssh-options' => "-i ~/.vagrant.d/insecure_private_key -l vagrant",
+  'ssh-options' => "-i " . $insecure_private_key . " -l vagrant",
   'db-url' => 'mysql://web:web@10.11.12.14:3306/web',
   'databases' => array (
     'default' => array (

--- a/puppet/shell/custom/example-drupal-post-provision.unprivileged.sh
+++ b/puppet/shell/custom/example-drupal-post-provision.unprivileged.sh
@@ -24,9 +24,6 @@ if [[ ! -d "/home/vagrant/.drush" ]]; then
   mkdir ~/.drush
 fi
 
-echo 'Copying aliases'
-find "${VAGRANT_CORE_FOLDER}" -maxdepth 1 -name "*.aliases.drushrc.php" -exec cp {} ~/.drush/ \;
-
 if [[ ! -f "/home/vagrant/.drush/drush.ini" ]]; then
   echo 'Creating drush settings'
   echo 'memory_limit = 512M' > ~/.drush/drush.ini


### PR DESCRIPTION
A tweak of https://github.com/forumone/web-starter/pull/158

Improve the local drush alias to better discover the vagrant private key.  The local alias should no longer need to be customized.

Removed the post-provision step that copies the alias file to ~/.drush.  The recommendation will now be to customize the alias file and copy it to your sites hierarchy (probably sites/all/drush).  Documentation will need to be updated if this gets in.
