### PR TITLE
Address problems with CentOS software collections and vagrant's sudo_command option

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,6 +91,10 @@ Vagrant.configure("2") do |config|
 
   config.ssh.forward_agent = true
 
+  # CentOS machines with Software Collections scripts (scl enable foo) have a misbehaving sudo that doesn't recognize flags.
+  # Override them to prevent cryptic errors about "line 8: -E: command not found"
+  config.ssh.sudo_command = "sudo %c"
+
   # Run any custom scripts before provisioning
   config.vm.provision :shell, :path => "puppet/shell/pre-provision.sh"
 


### PR DESCRIPTION
RedHat's `scl` scripts provide a wrapper script for the `sudo` command that does not respect arguments, leading to situations like the following:

```
$ sudo -E
/var/tmp/sclQzI0km: line 8: -E: command not found
```

Until the wrapper script is able to parse sudo flags, the solution is prevent Vagrant's SSH communicator plugin from passing flags to `sudo` when running commands. This PR addresses that by overriding `config.ssh.sudo_command` with `sudo %c` instead of the default, which is `sudo -E -k %c` (and the cause of the "line 8: -E" errors).
