### PR TITLE
Mandate all_squash for Linux hosts

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure("2") do |config|
       nfs_exports += ["noac", "actimeo=0", "intr", "noacl", "lookupcache=none"]
       synched_opts[:bsd__nfs_options] = nfs_exports
     elsif (RUBY_PLATFORM =~ /linux/)
+      nfs_exports += ["all_squash"]
       synched_opts[:linux__nfs_options] = nfs_exports
     end
   	


### PR DESCRIPTION
Some Linux-based NFS servers need the `all_squash` option in conjunction with Vagrant's own `map_uid` and `map_gid` options.

When SSH'ed in, the uid and gid of the `/vagrant` folder are still reported as being the host's, but the guest VM is able to modify files, so maybe it's a non-issue.
