### PR TITLE
Initial pass at Drupal 8 Capistrano platform.

### DIFF
--- a/capistrano/drupal8.rb
+++ b/capistrano/drupal8.rb
@@ -1,0 +1,83 @@
+# Revert the database when a rollback occurs
+Rake::Task["deploy:rollback_release_path"].enhance do
+  invoke "drupal8:revert_database"
+end
+
+# Backup the database when publishing a new release
+Rake::Task["deploy:publishing"].enhance ["drupal8:dbbackup"]
+
+# Copy drush aliases after linking the new release
+Rake::Task["deploy:symlink:release"].enhance ["drush:initialize"]
+
+# After publication run updates
+Rake::Task["deploy:published"].enhance do 
+  Rake::Task["drush:update"].invoke
+end
+
+namespace :drupal8 do
+  desc "Install Drupal"
+  task :install do
+    invoke 'drush:siteinstall'
+  end
+  
+  desc "Copy Drupal and web server configuration files"
+  task :settings do
+    on roles(:app) do
+      fetch(:site_folder).each do |folder|
+        # Find and link settings.php
+        if test " [ -e #{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/settings.php ]"
+          execute :rm, "-f", "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/settings.php"
+        end
+        execute :ln, '-s', "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/settings.#{fetch(:stage)}.php", "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/settings.php"
+
+        # Find and link services.yml
+        if test " [ -e #{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/services.yml ]"
+          execute :rm, "-f", "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/services.yml"
+        end
+        execute :ln, '-s', "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/services.#{fetch(:stage)}.yml", "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/services.yml"
+
+        # Set permissions on settings files and directory so Drupal doesn't complain. The permission values are set in lib/capistrano/tasks/drush.rake.
+        execute :chmod, fetch(:settings_file_perms), "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/settings.#{fetch(:stage)}.php"
+        execute :chmod, fetch(:settings_file_perms), "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}/services.#{fetch(:stage)}.yml"
+        execute :chmod, fetch(:site_directory_perms), "#{current_path}/#{fetch(:webroot, 'public')}/sites/#{folder}"
+      end
+        
+      # If a .htaccess file for the stage exists
+      if test " [ -f #{current_path}/#{fetch(:webroot, 'public')}/htaccess.#{fetch(:stage)} ]"
+        # If there is currently an .htaccess file
+        if test " [ -f #{current_path}/#{fetch(:webroot, 'public')}/.htaccess ]"
+          execute :rm, "#{current_path}/#{fetch(:webroot, 'public')}/.htaccess"
+        end
+        
+        execute :ln, '-s', "#{current_path}/#{fetch(:webroot, 'public')}/htaccess.#{fetch(:stage)}", "#{current_path}/#{fetch(:webroot, 'public')}/.htaccess"
+      end
+      
+      # If there a robots.txt file for the stage exists
+      if test " [ -f #{current_path}/#{fetch(:webroot, 'public')}/robots.#{fetch(:stage)}.txt ]"
+        if test " [ -f #{current_path}/#{fetch(:webroot, 'public')}/robots.txt ]"
+          execute :rm, "#{current_path}/#{fetch(:webroot, 'public')}/robots.txt"
+        end
+      
+        execute :ln, '-s', "#{current_path}/#{fetch(:webroot, 'public')}/robots.#{fetch(:stage)}.txt", "#{current_path}/#{fetch(:webroot, 'public')}/robots.txt"
+      end
+    end
+  end
+  
+  desc "Revert the database"
+  task :revert_database do
+    on roles(:db) do
+      last_release = capture(:ls, '-xr', releases_path).split.first
+      last_release_path = releases_path.join(last_release)
+      
+      within "#{last_release_path}/#{fetch(:app_webroot, 'public')}" do
+        execute :gunzip, "#{last_release_path}/db.sql.gz"
+      	execute :drush, "-y sql-drop -l #{fetch(:site_url)[0]} &&", %{$(drush sql-connect -l #{fetch(:site_url)[0]}) < #{last_release_path}/db.sql}
+      end
+    end
+  end
+  
+  desc "Backup the database"
+  task :dbbackup do
+    invoke "drush:sqldump"
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,7 +37,7 @@ set :ssh_options, {
 }
 
 # Platform
-set :platform, "drupal"
+set :platform, "drupal8"
 
 # rsync settings
 set :rsync_options, %w[--recursive --chmod=Dug=rwx,Do=rx --perms --delete --delete-excluded --exclude=.git* --exclude=node_modules]

--- a/lib/capistrano/tasks/drush.rake
+++ b/lib/capistrano/tasks/drush.rake
@@ -5,7 +5,7 @@
 # - :sqlsync: Copies a database from a remote Drupal site, assumes ENV['source'] provided which is a drush alias
 # - :rsync: Copies files from a remote Drupal site, assumes ENV['source'] provided which is a drush alias
 # - :sqldump: Dumps the database to the current revision's file system
-# - :cc: Clears the entire Drupal cache
+# - :cr: Rebuilds the entire Drupal cache
 # - :update: Runs all pending updates, including DB updates, Features and Configuration -- if set to use those
 # - :updatedb: Runs update hooks
 # - :features:revert: Reverts Features, which may be all Features or just Features in particular directories
@@ -128,11 +128,11 @@ namespace :drush do
   end
 
   desc "Clears the Drupal cache"
-  task :cc do
+  task :cr do
     on roles(:db) do
       within "#{release_path}/#{fetch(:app_webroot, 'public')}" do
         fetch(:site_url).each do |site|
-          execute :drush, "-y -p -r #{current_path}/#{fetch(:webroot, 'public')} -l #{site}", 'cc all'
+          execute :drush, "-y -p -r #{current_path}/#{fetch(:webroot, 'public')} -l #{site}", 'cr'
         end
       end
     end
@@ -145,7 +145,7 @@ namespace :drush do
       invoke 'drush:updatedb'
     end
     
-    invoke 'drush:cc'
+    invoke 'drush:cr'
 	
     # If we're using Features revert Features
     if fetch(:drupal_features)
@@ -167,7 +167,7 @@ namespace :drush do
         end
       end
       
-      invoke 'drush:cc'
+      invoke 'drush:cr'
     end
   end
   
@@ -198,7 +198,7 @@ namespace :drush do
         end
       end
       
-      invoke 'drush:cc'
+      invoke 'drush:cr'
     end
   end
 
@@ -225,7 +225,7 @@ namespace :drush do
         end
       end
 
-      invoke 'drush:cc'
+      invoke 'drush:cr'
     end
   end
 end


### PR DESCRIPTION
Drupal 8 will require some Capistrano configuration changes.
See also: #184 

For the time being, the approach discussed is to create a new 'drupal8' platform. This PR provides a first pass at that inspired by a few projects' existing implementation.

Also note that Drupal 8 requires Drush 8. If the deployment target uses an older Drush, hackery ensues along the lines of:
- Include Drush 8 in your repository (hopefully via Composer)
- Edit the Drush rake file to point to your Drush 8 script
- Edit the Drush rake file and drupal8 platform file created above to fetch this new path value
- Edit the Drush alias to point to your Drush 8 script

I can open a separate PR for that if you'd like, though we might want to smooth out the approach first.

I'm sure there will be much massaging here, but hopefully this gets us started!
